### PR TITLE
 Remove double quotes in create index ddl

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerDatabase.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/database/cloudspanner/CloudSpannerDatabase.java
@@ -94,7 +94,7 @@ public class CloudSpannerDatabase extends Database<CloudSpannerConnection> {
                 "    success BOOL NOT NULL\n" +
                 ") PRIMARY KEY (installed_rank DESC);\n" +
                 (baseline ? getBaselineStatement(table) + ";\n" : "") +
-                "CREATE INDEX " + table.getName() + "_s_idx ON " + table.getName() + " (\"success\");" +
+                "CREATE INDEX " + table.getName() + "_s_idx ON " + table.getName() + " (success);" +
                 "RUN BATCH;";
     }
 }


### PR DESCRIPTION
cause otherwise 
 INVALID_ARGUMENT: Error parsing Spanner DDL statement: CREATE INDEX flyway_schema_history_s_idx ON flyway_schema_history ("success") : Syntax error on line 1, column 68: Expecting ')' but found '"success"'
